### PR TITLE
fix: correct SOURCE_MAP.json path to assets/ subdirectory

### DIFF
--- a/skills/mastra/SKILL.md
+++ b/skills/mastra/SKILL.md
@@ -49,7 +49,7 @@ ls node_modules/@mastra/
 
    ```bash
    # Check what's available
-   cat node_modules/@mastra/core/dist/docs/SOURCE_MAP.json | grep '"Agent"'
+   cat node_modules/@mastra/core/dist/docs/assets/SOURCE_MAP.json | grep '"Agent"'
 
    # Read the actual type definition
    cat node_modules/@mastra/core/dist/[path-from-source-map]

--- a/skills/mastra/references/embedded-docs.md
+++ b/skills/mastra/references/embedded-docs.md
@@ -17,7 +17,8 @@ Look up API signatures from embedded docs in `node_modules/@mastra/*/dist/docs/`
 ```
 node_modules/@mastra/core/dist/docs/
 ├── SKILL.md           # Package overview, exports
-├── SOURCE_MAP.json    # Export→file mappings
+├── assets/
+│   └── SOURCE_MAP.json    # Export→file mappings
 └── [topics]/          # Feature docs (agents/, workflows/, etc.)
 ```
 
@@ -34,7 +35,7 @@ If you see packages like `core`, `memory`, `rag`, etc., proceed with embedded do
 ### 2. Find the export in SOURCE_MAP.json
 
 ```bash
-cat node_modules/@mastra/core/dist/docs/SOURCE_MAP.json | grep '"Agent"'
+cat node_modules/@mastra/core/dist/docs/assets/SOURCE_MAP.json | grep '"Agent"'
 ```
 
 Returns: `{ "Agent": { "types": "dist/agent/agent.d.ts", ... } }`
@@ -72,7 +73,7 @@ Topic docs provide conceptual explanations and usage examples.
 ls node_modules/@mastra/
 
 # Find specific export in SOURCE_MAP
-cat node_modules/@mastra/core/dist/docs/SOURCE_MAP.json | grep '"ExportName"'
+cat node_modules/@mastra/core/dist/docs/assets/SOURCE_MAP.json | grep '"ExportName"'
 
 # Read type definition from path
 cat node_modules/@mastra/core/dist/[path-from-source-map]
@@ -92,7 +93,7 @@ grep -r "functionName" node_modules/@mastra/core/src/
 **1. Find Agent in SOURCE_MAP:**
 
 ```bash
-cat node_modules/@mastra/core/dist/docs/SOURCE_MAP.json | grep '"Agent"'
+cat node_modules/@mastra/core/dist/docs/assets/SOURCE_MAP.json | grep '"Agent"'
 ```
 
 **2. Read the type definition:**


### PR DESCRIPTION
## Summary

Fixes incorrect documentation paths for `SOURCE_MAP.json`. The embedded docs references were using `dist/docs/SOURCE_MAP.json` but the actual path per Mastra's official documentation is `dist/docs/assets/SOURCE_MAP.json`.

## Changes

- **`skills/mastra/SKILL.md`** - Updated the example command path
- **`skills/mastra/references/embedded-docs.md`** - Updated directory structure diagram to show `assets/` folder, plus all command examples

## Before
```
node_modules/@mastra/core/dist/docs/
├── SKILL.md
├── SOURCE_MAP.json    ← incorrect
└── [topics]/
```

## After
```
node_modules/@mastra/core/dist/docs/
├── SKILL.md
├── assets/
│   └── SOURCE_MAP.json    ← correct
└── [topics]/
```
