### PR TITLE
fix(.claude-plugin): correct marketplace.json schema fields

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,9 +1,11 @@
 {
   "name": "mastra-agent-skills",
-  "version": "1.0.0",
-  "author": {
+  "owner": {
     "name": "Mastra",
     "email": "team@mastra.ai"
+  },
+  "metadata": {
+    "version": "1.0.0"
   },
   "plugins": [
     {


### PR DESCRIPTION
- Rename 'author' field to 'owner' (required field per official schema)
- Move 'version' to 'metadata.version' (correct location per schema)

https://code.claude.com/docs/en/plugin-marketplaces#owner-fields